### PR TITLE
Add new chains to network selector

### DIFF
--- a/packages/react-wallet/src/constants/chains.ts
+++ b/packages/react-wallet/src/constants/chains.ts
@@ -85,6 +85,51 @@ const newChains = [
     },
     testnet: true,
   },
+  {
+    id: 250,
+    name: 'Fantom',
+    nativeCurrency: {
+      name: 'FTM',
+      symbol: 'FTM',
+      decimals: 18,
+    },
+    rpcUrls: {
+      default: 'https://rpc.ankr.com/fantom/',
+    },
+    blockExplorers: {
+      etherscan: {
+        name: 'Etherscan',
+        url: 'https://ftmscan.com/',
+      },
+      default: {
+        name: 'default',
+        url: 'https://ftmscan.com/',
+      },
+    },
+  },
+  {
+    id: 4002,
+    name: 'Fantom Testnet',
+    nativeCurrency: {
+      name: 'FTM',
+      symbol: 'FTM',
+      decimals: 18,
+    },
+    rpcUrls: {
+      default: 'https://rpc.testnet.fantom.network/',
+    },
+    blockExplorers: {
+      etherscan: {
+        name: 'Etherscan',
+        url: 'https://testnet.ftmscan.com/',
+      },
+      default: {
+        name: 'default',
+        url: 'https://testnet.ftmscan.com/',
+      },
+    },
+    testnet: true,
+  },
 ];
 
 export const FLAIR_CHAINS: Chain[] = [...WagmiChains, ...newChains];

--- a/packages/react-wallet/src/constants/chains.ts
+++ b/packages/react-wallet/src/constants/chains.ts
@@ -130,6 +130,73 @@ const newChains = [
     },
     testnet: true,
   },
+  {
+    id: 1313161554,
+    name: 'Near (Aurora)',
+    nativeCurrency: {
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    },
+    rpcUrls: {
+      default: 'https://mainnet.aurora.dev',
+    },
+    blockExplorers: {
+      etherscan: {
+        name: 'Etherscan',
+        url: 'https://aurorascan.dev/',
+      },
+      default: {
+        name: 'default',
+        url: 'https://aurorascan.dev/',
+      },
+    },
+  },
+  {
+    id: 1313161555,
+    name: 'Near (Aurora) Testnet',
+    nativeCurrency: {
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    },
+    rpcUrls: {
+      default: 'https://testnet.aurora.dev/',
+    },
+    blockExplorers: {
+      etherscan: {
+        name: 'Etherscan',
+        url: 'https://testnet.aurorascan.dev/',
+      },
+      default: {
+        name: 'default',
+        url: 'https://testnet.aurorascan.dev/',
+      },
+    },
+    testnet: true,
+  },
+  {
+    id: 245022926,
+    name: 'Solana (Neon Devnet)',
+    nativeCurrency: {
+      name: 'NEON',
+      symbol: 'NEON',
+      decimals: 18,
+    },
+    rpcUrls: {
+      default: 'https://proxy.devnet.neonlabs.org/solana',
+    },
+    blockExplorers: {
+      etherscan: {
+        name: 'Etherscan',
+        url: 'https://neonscan.org/',
+      },
+      default: {
+        name: 'default',
+        url: 'https://neonscan.org/',
+      },
+    },
+  },
 ];
 
 export const FLAIR_CHAINS: Chain[] = [...WagmiChains, ...newChains];


### PR DESCRIPTION
## Description:

> Adding `Fantom`, `Near (Aurora)` and `Solana (Neon Devnet)` to network selector

## PR Checklist
- [x] :eyes: I have self-reviewed my PR, leaving comments on any changes which may trigger a discussion
- [ ] :pencil2: Added relevant tests
